### PR TITLE
fix: use friendly validation messages for email and password errors

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -26,14 +26,14 @@ User.init(
       allowNull: false,
       unique: true,
       validate: {
-        isEmail: true,
+        isEmail: { msg: 'Please enter a valid email address' },
       },
     },
     password: {
       type: DataTypes.STRING,
       allowNull: false,
       validate: {
-        len: [8, 128],
+        len: { args: [8, 128], msg: 'Password must be at least 8 characters' },
       },
     },
   },


### PR DESCRIPTION
- Unique constraint on username, password min 8 / max 128
- 409/400 errors return specific messages to the user instead of raw Sequelize output
- Track package-lock.json for reproducible installs